### PR TITLE
[#102] express 폴더 tsconfig 설정 변경

### DIFF
--- a/apps/express-server/tsconfig.json
+++ b/apps/express-server/tsconfig.json
@@ -1,22 +1,21 @@
 {
-  "extends": "@medi-map/tsconfig",
-
   "compilerOptions": {
     "target": "ES6",
-    "module": "commonjs",
     "rootDir": "src",
+    "module": "commonjs",
+    "resolveJsonModule": true,
     "outDir": "dist",
+    "esModuleInterop": true,
     "incremental": false,
-    "typeRoots": ["./src/types", "./node_modules/@types"],
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "typeRoots": ["./src/types", "./node_modules/@types"],
   },
-
   "ts-node": {
     "require": ["tsconfig-paths/register"],
-    "files": true
+    "files": true 
   },
   "include": ["src", "src/types"],
   "exclude": ["node_modules", "**/__tests__/*", "dist"]

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,12 @@
         "@medi-map/tsconfig"
       ]
     },
+    "dev": {
+      "dependsOn": [
+        "^lib:build"
+      ],
+      "cache": false
+    },
     "build": {
       "dependsOn": [
         "^build"


### PR DESCRIPTION
## #️⃣연관된 이슈
#102


## 📝작업 내용
- 모노레포 패키지에서 사용하고 있던 express 폴더 tsconfig에서 기존 파일로 변경
- model 및 마이그레이션 js 파일 진행으로 인한 타입 오류는 추후 보완예정


## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?