### PR TITLE
[#120] 약국 데이터 필터링 로직 개선

### DIFF
--- a/apps/express-server/src/routes/pharmacy/index.ts
+++ b/apps/express-server/src/routes/pharmacy/index.ts
@@ -67,6 +67,7 @@ router.get('/', async (req, res) => {
       throw new DatabaseError(ERROR_MESSAGES.DATABASE_ERROR);
     }
 
+    // 반경 내 약국 필터링
     const filteredPharmacies = pharmacies.filter((pharmacy: PharmacyAPIItem) =>
       isWithinRadius(centerLat, centerLng, pharmacy.wgs84Lat, pharmacy.wgs84Lon));
 

--- a/apps/express-server/src/routes/pharmacy/index.ts
+++ b/apps/express-server/src/routes/pharmacy/index.ts
@@ -4,13 +4,14 @@ import { Pharmacy } from '@/models';
 import { ValidationError, DatabaseError, UpdateError, UnexpectedError } from '@/error/CommonError';
 import { ERROR_MESSAGES } from '@/constants/errors';
 import { PharmacyAPIItem } from '@/types/pharmacy.types';
+import { Op } from 'sequelize';
 
 const router = Router();
 
 const EARTH_RADIUS = 6371e3; // 지구 반지름 (미터)
-const DEFAULT_RADIUS = 2500; // 기본 반경 (미터)
+const DEFAULT_RADIUS = 1500; // 기본 반경 (미터)
 
-// 유틸리티 함수: 거리 계산
+// 유틸리티 함수: 거리 계산 (Haversine Formula)
 const calculateDistance = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
   const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
 
@@ -24,7 +25,13 @@ const calculateDistance = (lat1: number, lon1: number, lat2: number, lon2: numbe
 };
 
 // 유틸리티 함수: 반경 내 확인
-const isWithinRadius = (originLat: number, originLng: number, targetLat: number, targetLng: number, radius: number = DEFAULT_RADIUS): boolean => {
+const isWithinRadius = (
+  originLat: number,
+  originLng: number,
+  targetLat: number,
+  targetLng: number,
+  radius: number = DEFAULT_RADIUS
+): boolean => {
   return calculateDistance(originLat, originLng, targetLat, targetLng) <= radius;
 };
 
@@ -40,15 +47,26 @@ router.get('/', async (req, res) => {
     const centerLat = parseFloat(lat as string);
     const centerLng = parseFloat(lng as string);
 
-    // 데이터베이스에서 모든 약국 데이터 조회
+    const latDiff = 0.0225; // 위도 변화량 (약 2.5km)
+    const lngDiff = 0.0270; // 경도 변화량 (약 2.5km)
+
+    const latMin = centerLat - latDiff;
+    const latMax = centerLat + latDiff;
+    const lngMin = centerLng - lngDiff;
+    const lngMax = centerLng + lngDiff;
+
     let pharmacies;
     try {
-      pharmacies = await Pharmacy.findAll();
+      pharmacies = await Pharmacy.findAll({
+        where: {
+          wgs84Lat: { [Op.between]: [latMin, latMax] },
+          wgs84Lon: { [Op.between]: [lngMin, lngMax] },
+        },
+      });
     } catch (error) {
       throw new DatabaseError(ERROR_MESSAGES.DATABASE_ERROR);
     }
 
-    // 반경 내 약국 필터링
     const filteredPharmacies = pharmacies.filter((pharmacy: PharmacyAPIItem) =>
       isWithinRadius(centerLat, centerLng, pharmacy.wgs84Lat, pharmacy.wgs84Lon));
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#120 


## 📝작업 내용
- 약국 조회 시 db 필터링 적용
- 기존) 모든 약국 데이터를 조회한 후 필터링
- 수정 후) Sequelize Op.between 연산자를 활용하여 특정 범위 내 약국만 조회


## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?